### PR TITLE
AccessToken 재발급 로직 수정

### DIFF
--- a/src/main/java/com/project/Teaming/domain/project/controller/ProjectParticipateController.java
+++ b/src/main/java/com/project/Teaming/domain/project/controller/ProjectParticipateController.java
@@ -1,5 +1,6 @@
 package com.project.Teaming.domain.project.controller;
 
+import com.project.Teaming.domain.project.dto.request.JoinTeamDto;
 import com.project.Teaming.domain.project.dto.response.ProjectParticipationInfoDto;
 import com.project.Teaming.domain.project.service.ProjectParticipationService;
 import com.project.Teaming.global.result.ResultCode;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -25,10 +27,10 @@ public class ProjectParticipateController {
 
     private final ProjectParticipationService projectParticipationService;
 
-    @PostMapping("/project/join/{team_id}")
+    @PostMapping("/project/join")
     @Operation(summary = "프로젝트 팀에 신청", description = "팀원으로 들어가길 원하는 사용자가 팀에 신청을 하면 대기열에 등록된다.")
-    public ResultDetailResponse<Void> joinProjectTeam(@PathVariable Long team_id) {
-        projectParticipationService.joinTeam(team_id);
+    public ResultDetailResponse<Void> joinProjectTeam(@RequestBody JoinTeamDto dto) {
+        projectParticipationService.joinTeam(dto);
         return new ResultDetailResponse<>(ResultCode.JOIN_MEMBER_PROJECT_TEAM, null);
     }
 

--- a/src/main/java/com/project/Teaming/domain/project/dto/request/JoinTeamDto.java
+++ b/src/main/java/com/project/Teaming/domain/project/dto/request/JoinTeamDto.java
@@ -1,0 +1,10 @@
+package com.project.Teaming.domain.project.dto.request;
+
+import lombok.Data;
+
+@Data
+public class JoinTeamDto {
+
+    private Long teamId;
+    private String recruitCategory;
+}

--- a/src/main/java/com/project/Teaming/domain/project/dto/response/ProjectParticipationInfoDto.java
+++ b/src/main/java/com/project/Teaming/domain/project/dto/response/ProjectParticipationInfoDto.java
@@ -16,6 +16,7 @@ public class ProjectParticipationInfoDto {
     private String requestDate;
     private String decisionDate;
     private String role;
+    private String recruitCategory;
     private int reportingCnt;
 
     public ProjectParticipationInfoDto(ProjectParticipation participation) {
@@ -27,6 +28,7 @@ public class ProjectParticipationInfoDto {
         this.requestDate = getFormattedDate(participation.getRequestDate());
         this.decisionDate = participation.getDecisionDate() != null ? getFormattedDate(participation.getDecisionDate()) : "-";
         this.role = participation.getRole().toString();
+        this.recruitCategory = participation.getRecruitCategory();
         this.reportingCnt = participation.getReportingCnt();
     }
 

--- a/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
+++ b/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
@@ -1,19 +1,15 @@
 package com.project.Teaming.domain.project.entity;
 
-import com.project.Teaming.domain.user.entity.Report;
 import com.project.Teaming.domain.user.entity.User;
 import com.project.Teaming.global.error.ErrorCode;
 import com.project.Teaming.global.error.exception.BusinessException;
 import jakarta.persistence.*;
-import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -45,6 +41,9 @@ public class ProjectParticipation {
     @Column(name = "reporting_cnt", nullable = false, columnDefinition = "INT DEFAULT 0")
     private int reportingCnt;  // 신고 누적
 
+    @Column(nullable = false)
+    private String recruitCategory;  // 프로젝트 팀에 지원 시 신청자가 선택하는 모집 구분
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;  // 사용자 ID (주인)
@@ -59,15 +58,17 @@ public class ProjectParticipation {
         this.requestDate = LocalDateTime.now();
         this.decisionDate = LocalDateTime.now();
         this.role = ProjectRole.OWNER;
+        this.recruitCategory = "OWNER";
         this.user = user;
         this.projectTeam = team;
     }
 
-    public void joinTeamMember(User user, ProjectTeam projectTeam) {
+    public void joinTeamMember(User user, ProjectTeam projectTeam, String recruitCategory) {
         this.participationStatus = ParticipationStatus.PENDING;
         this.isDeleted = false;
         this.requestDate = LocalDateTime.now();
         this.role = ProjectRole.MEMBER;
+        this.recruitCategory = recruitCategory;
         this.user = user;
         this.projectTeam = projectTeam;
     }

--- a/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
+++ b/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
@@ -1,5 +1,6 @@
 package com.project.Teaming.domain.project.service;
 
+import com.project.Teaming.domain.project.dto.request.JoinTeamDto;
 import com.project.Teaming.domain.project.dto.response.ProjectParticipationInfoDto;
 import com.project.Teaming.domain.project.entity.ParticipationStatus;
 import com.project.Teaming.domain.project.entity.ProjectParticipation;
@@ -47,15 +48,15 @@ public class ProjectParticipationService {
         return securityUser.getUserId();
     }
 
-    public void joinTeam(Long teamId) {
-        ProjectTeam projectTeam = projectTeamRepository.findById(teamId)
+    public void joinTeam(JoinTeamDto dto) {
+        ProjectTeam projectTeam = projectTeamRepository.findById(dto.getTeamId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_TEAM));
 
         User user = userRepository.findById(getCurrentId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
 
         // 이미 팀에 참여했는지 여부 확인
-        Optional<ProjectParticipation> existingParticipation = projectParticipationRepository.findByProjectTeamIdAndUserId(teamId, user.getId());
+        Optional<ProjectParticipation> existingParticipation = projectParticipationRepository.findByProjectTeamIdAndUserId(dto.getTeamId(), user.getId());
         if (existingParticipation.isPresent()) {
             ProjectParticipation participation = existingParticipation.get();
             if (participation.getRole() == ProjectRole.OWNER) {
@@ -67,7 +68,7 @@ public class ProjectParticipationService {
 
         // 새로운 팀에 참여
         ProjectParticipation newParticipation = new ProjectParticipation();
-        newParticipation.joinTeamMember(user, projectTeam);
+        newParticipation.joinTeamMember(user, projectTeam, dto.getRecruitCategory());
         projectParticipationRepository.save(newParticipation);
     }
 

--- a/src/main/java/com/project/Teaming/global/error/ErrorCode.java
+++ b/src/main/java/com/project/Teaming/global/error/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
 
     // Auth
     REFRESH_TOKEN_INVALID(400, "A001", "refresh token invalid"),
+    REFRESH_TOKEN_NOT_IN_REDIS(400, "A002", "RefreshToken이 Redis에 존재하지 않습니다."),
+
 
     // Portfolio
     PORTFOLIO_NOT_EXIST(404, "P001", "포트폴리오를 찾을 수 없습니다."),

--- a/src/main/java/com/project/Teaming/global/jwt/RefreshTokenService.java
+++ b/src/main/java/com/project/Teaming/global/jwt/RefreshTokenService.java
@@ -1,5 +1,7 @@
 package com.project.Teaming.global.jwt;
 
+import com.project.Teaming.global.error.ErrorCode;
+import com.project.Teaming.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,19 @@ public class RefreshTokenService {
     @Transactional
     public void saveTokenInfo(String email, String refreshToken, String accessToken) {
         repository.save(new RefreshToken(email, accessToken, refreshToken));
+    }
+
+    @Transactional
+    public void saveNewAccessTokenInfo(String email, String accessToken) {
+        // 이메일을 기준으로 RefreshToken 조회
+        RefreshToken token = repository.findById(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_IN_REDIS));
+
+        // AccessToken 갱신
+        token.updateAccessToken(accessToken);
+
+        // 변경된 엔티티를 저장 (갱신)
+        repository.save(token);
     }
 
     @Transactional

--- a/src/main/java/com/project/Teaming/global/jwt/controller/AuthController.java
+++ b/src/main/java/com/project/Teaming/global/jwt/controller/AuthController.java
@@ -1,27 +1,27 @@
 package com.project.Teaming.global.jwt.controller;
 
+import com.project.Teaming.global.error.ErrorCode;
+import com.project.Teaming.global.error.exception.BusinessException;
 import com.project.Teaming.global.jwt.*;
 import com.project.Teaming.global.jwt.dto.StatusResponseDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Optional;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final RefreshTokenRepository tokenRepository;
     private final RefreshTokenService tokenService;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository repository;
 
     @PostMapping("token/logout")
     public ResponseEntity<StatusResponseDto> logout(HttpServletResponse response, @CookieValue(value = "accessToken" , required = false) String accessToken) {
@@ -44,42 +44,47 @@ public class AuthController {
     }
 
     @PostMapping("token/refresh")
-    public ResponseEntity<TokenResponseStatus> refresh(@CookieValue(value = "accessToken", required = false) String accessToken, HttpServletResponse response) {
+    public ResponseEntity<TokenResponseStatus> refresh(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response) {
 
-        if (accessToken == null) {
+        if (refreshToken == null) {
             return ResponseEntity.badRequest().body(TokenResponseStatus.addStatus(400, null));
         }
-        // 액세스 토큰으로 Refresh 토큰 객체를 조회
-        Optional<RefreshToken> refreshToken = tokenRepository.findByAccessToken(accessToken);
-        log.info("Access Token from Cookie: {}", accessToken);
 
-        // RefreshToken이 존재하고 유효하다면 실행
-        if (refreshToken.isPresent() && jwtUtil.verifyToken(refreshToken.get().getRefreshToken())) {
-            // RefreshToken 객체를 꺼내온다.
-            RefreshToken resultToken = refreshToken.get();
-
-            // 권한과 아이디를 추출해 새로운 액세스토큰을 만든다.
-            String newAccessToken = jwtUtil.generateAccessToken(resultToken.getId(), jwtUtil.getRole(resultToken.getRefreshToken()));
-            log.info("accessToken={}", newAccessToken);
-
-            // 액세스 토큰의 값을 수정해준다.
-            resultToken.updateAccessToken(newAccessToken);
-            tokenRepository.save(resultToken);
-
-            // 새로운 AccessToken을 HttpOnly 쿠키로 설정
-            ResponseCookie newAccessTokenCookie = ResponseCookie.from("accessToken", newAccessToken)
-                    .httpOnly(true)
-                    .secure(true)
-                    .sameSite("None")   // 교차 출처 요청 허용
-                    .domain("myspringserver.shop")
-                    .path("/")
-                    .maxAge(1800) // 유효 기간 설정
-                    .build();
-            response.addHeader("Set-Cookie", newAccessTokenCookie.toString());
-
-            // 새로운 액세스 토큰을 반환해준다.
-            return ResponseEntity.ok(TokenResponseStatus.addStatus(200, newAccessToken));
+        // RefreshToken 검증
+        if (!jwtUtil.verifyToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(TokenResponseStatus.addStatus(401, null));
         }
-        return ResponseEntity.badRequest().body(TokenResponseStatus.addStatus(400, null));
+
+        // 리프레시 토큰에서 사용자 ID와 권한 추출
+        String userEmail = jwtUtil.getUid(refreshToken);
+
+        // Redis에 저장된 RefreshToken 조회
+        RefreshToken storedToken = repository.findById(userEmail)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_IN_REDIS));
+
+        // 요청된 리프레시 토큰과 Redis에 저장된 토큰 비교
+        if (!storedToken.getRefreshToken().equals(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(TokenResponseStatus.addStatus(401, null));
+        }
+
+        // 새로운 액세스 토큰 생성
+        String userRole = jwtUtil.getRole(refreshToken);
+        String newAccessToken = jwtUtil.generateAccessToken(userEmail, userRole);
+        log.info("새로 발급된 Access Token: {}", newAccessToken);
+
+        // 새로운 AccessToken을 HttpOnly 쿠키로 설정
+        ResponseCookie newAccessTokenCookie = ResponseCookie.from("accessToken", newAccessToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")   // 교차 출처 요청 허용
+                .domain("myspringserver.shop")
+                .path("/")
+                .maxAge(1800) // 유효 기간 설정
+                .build();
+        response.addHeader("Set-Cookie", newAccessTokenCookie.toString());
+        tokenService.saveNewAccessTokenInfo(userEmail, newAccessToken);
+
+        // 새로운 액세스 토큰을 반환해준다.
+        return ResponseEntity.ok(TokenResponseStatus.addStatus(200, newAccessToken));
     }
 }

--- a/src/main/java/com/project/Teaming/global/oauth2/MyAuthenticationSuccessHandler.java
+++ b/src/main/java/com/project/Teaming/global/oauth2/MyAuthenticationSuccessHandler.java
@@ -59,6 +59,7 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
             GeneratedToken token = jwtUtil.generateToken(email, role);
             log.debug("MyAuthenticationSuccessHandler 권한 처리 후 role : " + role);
             log.info("accessToken={}", token.getAccessToken());
+            log.info("refreshToken={}", token.getRefreshToken());
 
             // accessToken 을 HttpOnly 쿠키에 저장
             ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", token.getAccessToken())
@@ -70,7 +71,19 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
                     .maxAge(1800)  // 30분 유효
                     .build();
             response.addHeader("Set-Cookie", accessTokenCookie.toString());
-            log.info("Set-Cookie Header: " + accessTokenCookie.toString());
+
+            // refreshToken 을 HttpOnly 쿠키에 저장
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", token.getRefreshToken())
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("None")
+                    .domain("myspringserver.shop")
+                    .path("/")
+                    .maxAge(1209600)  // 2주 유효
+                    .build();
+            response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+            log.info("Set-Cookie AccessToken Header: " + accessTokenCookie.toString());
+            log.info("Set-Cookie RefreshToken Header: " + refreshTokenCookie.toString());
 
             // 추가 정보 기입 여부에 따라 리다이렉트 경로 설정
             String targetUrl;
@@ -89,6 +102,7 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
             // jwt token 발행
             GeneratedToken token = jwtUtil.generateToken(email, role);
             log.info("accessToken={}", token.getAccessToken());
+            log.info("refreshToken={}", token.getRefreshToken());
 
             // accessToken 을 HttpOnly 쿠키에 저장
             ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", token.getAccessToken())
@@ -100,7 +114,19 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
                     .maxAge(1800)  // 30분 유효
                     .build();
             response.addHeader("Set-Cookie", accessTokenCookie.toString());
+
+            // RefreshToken 을 HttpOnly 쿠키에 저장
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", token.getRefreshToken())
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("None")
+                    .domain("myspringserver.shop")
+                    .path("/")
+                    .maxAge(1209600) // 2주 유효
+                    .build();
+            response.addHeader("Set-Cookie", refreshTokenCookie.toString());
             log.info("Set-Cookie Header: " + accessTokenCookie.toString());
+            log.info("Set-Cookie RefreshToken Header: " + refreshTokenCookie.toString());
 
             // 회원가입 페이지로 리다이렉트
             String targetUrl = "https://front.myspringserver.shop:3000/sign-up";


### PR DESCRIPTION
## 📌 연관된 이슈 
<!-- 이슈 번호를 작성해주세요. ex) #이슈번호, ... -->
#5 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- [x] 프로젝트 팀에 신청 로직 수정
- [x] 토큰 재발급 로직 수정
  - 로직
    1. 클라이언트가 API 요청 시, AccessToken을 전송하지만 AccessToken이 만료된 경우, 서버는 401 Unauthorized 응답을 반환한다.
    2. 클라이언트는 401 응답을 수신하면 토큰 갱신 엔드포인트로 새 요청을 보내며 이 요청에는 HttpOnly 쿠키에 저장된 RefreshToken이 자동으로 포함된다. (클라이언트는 RefreshToken을 직접 핸들링할 수 없다.)
    3. 서버는 요청으로 전달된 RefreshToken을 Redis에 저장된 값과 비교하고, 검증에 성공하면 새로운 AccessToken을 발급하고 클라이언트에 반환한다. (새로 발급받은 AccessToken은 다시 Redis에 갱신 후 저장한다.)
    4. 클라이언트는 새로 발급받은 AccessToken으로 인증 요청을 이어간다.
  - 비고
    - 로그인 성공 시, 기존에는 쿠키에 AccessToken만 저장했지만 토큰 재발급은 RefreshToken이 필요하며, 토큰 만료 시 AccessToken은 삭제되기 때문에 AccessToken과 RefreshToken 모두 쿠키에 저장되도록 한다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
