### PR TITLE
feat: 팀원 신고 API

### DIFF
--- a/src/main/java/com/project/Teaming/domain/project/controller/ProjectParticipateController.java
+++ b/src/main/java/com/project/Teaming/domain/project/controller/ProjectParticipateController.java
@@ -1,6 +1,7 @@
 package com.project.Teaming.domain.project.controller;
 
 import com.project.Teaming.domain.project.dto.request.JoinTeamDto;
+import com.project.Teaming.domain.project.dto.request.ReportDto;
 import com.project.Teaming.domain.project.dto.response.ProjectParticipationInfoDto;
 import com.project.Teaming.domain.project.dto.response.ProjectTeamMemberDto;
 import com.project.Teaming.domain.project.service.ProjectParticipationService;
@@ -82,5 +83,12 @@ public class ProjectParticipateController {
     public ResultDetailResponse<Void> exportTeamMember(@PathVariable Long team_id, @PathVariable Long user_id) {
         projectParticipationService.exportMember(team_id, user_id);
         return new ResultDetailResponse<>(ResultCode.EXPORT_TEAM_MEMBER, null);
+    }
+
+    @PostMapping("project/report")
+    @Operation(summary = "프로젝트 팀 내 팀원 신고", description = "프로젝트 내의 팀원들은 팀원에 대하여 신고를 할 수 있다.")
+    public ResultDetailResponse<Void> reportUser(@RequestBody ReportDto dto) {
+        projectParticipationService.reportUser(dto.getTeamId(), dto.getReportedUserId());
+        return new ResultDetailResponse<>(ResultCode.REPORT_MEMBER, null);
     }
 }

--- a/src/main/java/com/project/Teaming/domain/project/dto/request/ReportDto.java
+++ b/src/main/java/com/project/Teaming/domain/project/dto/request/ReportDto.java
@@ -1,0 +1,9 @@
+package com.project.Teaming.domain.project.dto.request;
+
+import lombok.Data;
+
+@Data
+public class ReportDto {
+    private Long teamId;
+    private Long reportedUserId;           // 신고 대상 사용자 ID
+}

--- a/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
+++ b/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
@@ -20,4 +20,6 @@ public interface ProjectParticipationRepository extends JpaRepository<ProjectPar
     List<ProjectParticipation> findByUserIdAndParticipationStatus(Long userId, ParticipationStatus status);
 
     List<ProjectParticipation> findByProjectTeamIdAndParticipationStatus(Long projectTeamId, ParticipationStatus status);
+
+    Optional<ProjectParticipation> findByProjectTeamIdAndUserIdAndParticipationStatus(Long projectId, Long userId, ParticipationStatus status);
 }

--- a/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
+++ b/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
@@ -22,4 +22,6 @@ public interface ProjectParticipationRepository extends JpaRepository<ProjectPar
     List<ProjectParticipation> findByProjectTeamIdAndParticipationStatus(Long projectTeamId, ParticipationStatus status);
 
     Optional<ProjectParticipation> findByProjectTeamIdAndUserIdAndParticipationStatus(Long projectId, Long userId, ParticipationStatus status);
+
+    long countByProjectTeamIdAndParticipationStatusAndIsDeleted(Long teamId, ParticipationStatus status, boolean delete);
 }

--- a/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
+++ b/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
@@ -9,7 +9,9 @@ import com.project.Teaming.domain.project.entity.ProjectRole;
 import com.project.Teaming.domain.project.entity.ProjectTeam;
 import com.project.Teaming.domain.project.repository.ProjectParticipationRepository;
 import com.project.Teaming.domain.project.repository.ProjectTeamRepository;
+import com.project.Teaming.domain.user.entity.Report;
 import com.project.Teaming.domain.user.entity.User;
+import com.project.Teaming.domain.user.repository.ReportRepository;
 import com.project.Teaming.domain.user.repository.UserRepository;
 import com.project.Teaming.global.error.ErrorCode;
 import com.project.Teaming.global.error.exception.BusinessException;
@@ -33,6 +35,7 @@ public class ProjectParticipationService {
     private final ProjectParticipationRepository projectParticipationRepository;
     private final ProjectTeamRepository projectTeamRepository;
     private final UserRepository userRepository;
+    private final ReportRepository reportRepository;
 
     public void createParticipation(ProjectTeam projectTeam) {
         ProjectParticipation projectParticipation = new ProjectParticipation();
@@ -170,12 +173,36 @@ public class ProjectParticipationService {
             throw new BusinessException(ErrorCode.USER_NOT_PART_OF_TEAM);
         }
 
+        // 로그인 사용자가 팀원인지 판별
+        ProjectParticipation reporterParticipation = projectParticipationRepository
+                .findByProjectTeamIdAndUserIdAndParticipationStatus(teamId, user.getId(), ParticipationStatus.ACCEPTED)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_PART_OF_TEAM));
+
         return teamMembers.stream()
                 .map(member -> {
                     ProjectTeamMemberDto dto = new ProjectTeamMemberDto(member);
                     dto.setLoginUser(member.getUser().getId().equals(user.getId()));  // 로그인 한 유저인지
+                    boolean isReported = reportRepository.existsByProjectParticipationAndReportedUser(reporterParticipation, member.getUser());
+                    dto.setReported(isReported);
                     return dto;
                 })
                 .collect(Collectors.toList());
+    }
+
+    public void reportUser(Long teamId, Long reportedUserId) {
+        User reporter = userRepository.findById(getCurrentId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
+
+        // 신고자의 참여 정보 조회
+        ProjectParticipation reporterParticipation = projectParticipationRepository.findByProjectTeamIdAndUserId(teamId, reporter.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_PARTICIPATION));
+
+        // 신고 대상의 참여 정보 조회
+        ProjectParticipation reportedParticipation = projectParticipationRepository.findByProjectTeamIdAndUserId(
+                        reporterParticipation.getProjectTeam().getId(), reportedUserId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REPORT_TARGET));
+
+        Report report = Report.projectReport(reporterParticipation, reportedParticipation.getUser());
+        reportRepository.save(report);
     }
 }

--- a/src/main/java/com/project/Teaming/domain/user/entity/Report.java
+++ b/src/main/java/com/project/Teaming/domain/user/entity/Report.java
@@ -21,18 +21,25 @@ public class Report extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "report_id")
     private Long id;  // 신고 ID
+
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private ReportStatus status;  // 신고 상태
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_participation_id", referencedColumnName = "par_id",nullable = true)
     private ProjectParticipation projectParticipation;  // 프로젝트 유저 ID (FK)
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mentoring_participation_id", referencedColumnName = "mp_id",nullable = true)
     private MentoringParticipation mentoringParticipation;  // 멘토링 유저 ID (FK)
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reported_user_id", referencedColumnName = "user_id", nullable = false)
     private User reportedUser;  // 신고 당한 사용자 ID (FK)
+
+    @Column(name = "warning_processed", nullable = false)
+    private boolean warningProcessed; // warningCnt 증가 처리 여부
 
     @PrePersist
     @PreUpdate
@@ -48,6 +55,7 @@ public class Report extends BaseTimeEntity {
         report.projectParticipation = reporterParticipation;
         report.reportedUser = reportedUser;
         report.status = ReportStatus.REPORTED;
+        report.warningProcessed = false;
         return report;
     }
 }

--- a/src/main/java/com/project/Teaming/domain/user/entity/Report.java
+++ b/src/main/java/com/project/Teaming/domain/user/entity/Report.java
@@ -42,4 +42,12 @@ public class Report extends BaseTimeEntity {
             throw new BusinessException(ErrorCode.CHOOSE_ONE_DOMAIN);
         }
     }
+
+    public static Report projectReport(ProjectParticipation reporterParticipation, User reportedUser) {
+        Report report = new Report();
+        report.projectParticipation = reporterParticipation;
+        report.reportedUser = reportedUser;
+        report.status = ReportStatus.REPORTED;
+        return report;
+    }
 }

--- a/src/main/java/com/project/Teaming/domain/user/entity/User.java
+++ b/src/main/java/com/project/Teaming/domain/user/entity/User.java
@@ -82,4 +82,8 @@ public class User extends BaseTimeEntity {
         this.name = name;
         this.portfolio = portfolio;
     }
+
+    public void incrementWarningCnt() {
+        this.warningCnt += 1;
+    }
 }

--- a/src/main/java/com/project/Teaming/domain/user/repository/ReportRepository.java
+++ b/src/main/java/com/project/Teaming/domain/user/repository/ReportRepository.java
@@ -4,7 +4,18 @@ import com.project.Teaming.domain.project.entity.ProjectParticipation;
 import com.project.Teaming.domain.user.entity.Report;
 import com.project.Teaming.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
     boolean existsByProjectParticipationAndReportedUser(ProjectParticipation reporter, User reportedUser);
+
+    // 처리되지 않은 신고 수 조회
+    long countByReportedUserIdAndProjectParticipation_ProjectTeamIdAndWarningProcessedFalse(Long reportedUserId, Long teamId);
+
+    // warningProcessed를 true로 업데이트
+    @Modifying
+    @Query("UPDATE Report r SET r.warningProcessed = true WHERE r.reportedUser.id = :reportedUserId AND r.projectParticipation.projectTeam.id = :teamId AND r.warningProcessed = false")
+    void updateWarningProcessedByReportedUserAndTeamId(@Param("reportedUserId") Long reportedUserId, @Param("teamId") Long teamId);
 }

--- a/src/main/java/com/project/Teaming/domain/user/repository/ReportRepository.java
+++ b/src/main/java/com/project/Teaming/domain/user/repository/ReportRepository.java
@@ -1,0 +1,10 @@
+package com.project.Teaming.domain.user.repository;
+
+import com.project.Teaming.domain.project.entity.ProjectParticipation;
+import com.project.Teaming.domain.user.entity.Report;
+import com.project.Teaming.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    boolean existsByProjectParticipationAndReportedUser(ProjectParticipation reporter, User reportedUser);
+}

--- a/src/main/java/com/project/Teaming/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/Teaming/global/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                                 "project/team/{team_id}/delete", "/project/join/**", "/user/report", "/user/update/**", "/project/{team_id}/quit",
                                 "/project/team/{team_id}/{user_id}/**", "/project/post/{team_id}", "/project/post/{team_id}/{post_id}/edit",
                                 "/project/post/{team_id}/{post_id}/complete", "/user", "/project/team/{team_id}/member/**", "/project/team/status",
-                                "/user/project", "/project/team/{team_id}/member").hasRole("USER")
+                                "/user/project", "/project/team/{team_id}/member", "/project/report").hasRole("USER")
                         .anyRequest().authenticated() // 그 외 모든 요청 인증 필요
                 );
 

--- a/src/main/java/com/project/Teaming/global/error/ErrorCode.java
+++ b/src/main/java/com/project/Teaming/global/error/ErrorCode.java
@@ -61,7 +61,10 @@ public enum ErrorCode {
     NOT_A_LEADER(404, "M007", "수락할 수 있는 권한이 없습니다."),
     STATUS_IS_NOT_PENDING(404, "M008", "이미 수락 또는 거절된 지원자 입니다"),
     EXPORTED_BY_TEAM(404, "M009", "이미 강퇴된 팀 입니다."),
-    NOT_A_MEMBER(404, "M010", "팀 구성원이 아닙니다.");
+    NOT_A_MEMBER(404, "M010", "팀 구성원이 아닙니다."),
+
+    // Report
+    INVALID_REPORT_TARGET(404, "R001", "신고자를 찾을 수 없습니다.");
 
     private int status;
     private final String code;

--- a/src/main/java/com/project/Teaming/global/result/ResultCode.java
+++ b/src/main/java/com/project/Teaming/global/result/ResultCode.java
@@ -45,6 +45,7 @@ public enum ResultCode {
     UPDATE_TEAM_STATUS(200, "P018", "프로젝트 팀 상태 변경 완료"),
     GET_MY_PROJECT(200, "P019", "참여 중인 프로젝트 조회 완료"),
     GET_MEMBER_LIST(200, "P020", "프로젝트 멤버 조회 완료"),
+    REPORT_MEMBER(200, "P021", "팀원 신고 완료"),
 
     //Mentoring
     REGISTER_MENTORING_TEAM(200,"M001","멘토링 팀 등록 완료"),


### PR DESCRIPTION
## 📌 연관된 이슈 
<!-- 이슈 번호를 작성해주세요. ex) #이슈번호, ... -->
#61 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- [x] 팀원 신고 API
- [x] 팀원 신고 시, warningCnt 증가 로직 추가
  - 팀의 과반수 이상의 인원이 팀 내의 특정 팀원을 신고하면 해당 유저의 warningCnt가 1만큼 증가한다.
  - 과반수 이상의 인원이 신고를 할 때마다 warningCnt가 증가될 수 있으므로 이에 대한 중복 처리를 방지하기 위해 warningProcessed boolean 값을 추가하여 판단
- [x] 팀원 목록 조회 시, 로그인 한 사용자(본인)의 입장에서 본인이 각 팀원들에 대한 신고 여부를 판단하는 boolean값인 isReported 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
