### PR TITLE
TeamCategory 분리

### DIFF
--- a/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringBoardController.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringBoardController.java
@@ -96,7 +96,7 @@ public class MentoringBoardController {
     }
 
     @PostMapping("/post/{team_id}/{post_id}/complete")
-    @Operation(summary = "게시물 모집 완료 처리", description = "게시물에서 팀장이 모집 완료 처리를 직접 할 수 있다.")
+    @Operation(summary = "게시물 모집 완료 처리", description = "게시물에서 팀구성원이 모집 완료 처리를 직접 할 수 있다.")
     public ResultDetailResponse<MentoringPostStatusDto> completePostStatus(@PathVariable Long team_id, @PathVariable Long post_id) {
         MentoringPostStatusDto statusDto = mentoringBoardService.updatePostStatus(team_id, post_id);
         return new ResultDetailResponse<>(ResultCode.UPDATE_POST_STATUS,statusDto);

--- a/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringParticipationController.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringParticipationController.java
@@ -41,7 +41,7 @@ public class MentoringParticipationController {
         MentoringBoard mentoringPost = mentoringBoardService.findMentoringPost(post_id);
         MentoringTeam mentoringTeam = mentoringPost.getMentoringTeam();
         RqParticipationDto participationDto = new RqParticipationDto(MentoringAuthority.NoAuth, MentoringParticipationStatus.PENDING, mentoringPost.getRole());
-        Long id = mentoringParticipationService.saveMentoringParticipation(mentoringTeam.getId(), participationDto);
+        Long id = mentoringParticipationService.saveMentoringParticipation(mentoringTeam, participationDto);
         return new ResultDetailResponse<>(ResultCode.REGISTER_MENTORING_PARTICIPATION, String.valueOf(id));
     }
 

--- a/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringTeamController.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringTeamController.java
@@ -9,6 +9,7 @@ import com.project.Teaming.domain.mentoring.entity.MentoringParticipationStatus;
 import com.project.Teaming.domain.mentoring.entity.MentoringTeam;
 import com.project.Teaming.domain.mentoring.service.MentoringParticipationService;
 import com.project.Teaming.domain.mentoring.service.MentoringTeamService;
+import com.project.Teaming.domain.mentoring.service.TeamCategoryService;
 import com.project.Teaming.domain.user.entity.User;
 import com.project.Teaming.domain.user.service.UserService;
 import com.project.Teaming.global.jwt.dto.SecurityUserDto;
@@ -36,7 +37,6 @@ import java.util.stream.Collectors;
 public class MentoringTeamController {
 
     private final MentoringTeamService mentoringTeamService;
-    private final MentoringParticipationService mentoringParticipationService;
 
     @PostMapping("/team")
     @Operation(summary = "멘토링 팀 저장", description = "멘토링 팀을 생성하고 저장할 수 있으며, 멘토링 팀을 생성한 유저는 팀의 리더가 된다,  " +
@@ -45,8 +45,6 @@ public class MentoringTeamController {
     public ResultDetailResponse<String> saveMentoringTeam(@RequestBody @Valid RqTeamDto dto) {
         log.info("SecurityContext Authentication: {}", SecurityContextHolder.getContext().getAuthentication());
         Long savedId = mentoringTeamService.saveMentoringTeam(dto);
-        RqParticipationDto participationDto = new RqParticipationDto(MentoringAuthority.LEADER, MentoringParticipationStatus.ACCEPTED, dto.getRole());
-        mentoringParticipationService.saveMentoringParticipation(savedId, participationDto);
         return new ResultDetailResponse<>(ResultCode.REGISTER_MENTORING_TEAM, String.valueOf(savedId));
     }
 

--- a/src/main/java/com/project/Teaming/domain/mentoring/dto/request/RqTeamDto.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/dto/request/RqTeamDto.java
@@ -25,7 +25,6 @@ public class RqTeamDto {
     private int mentoringCnt;
     @NotBlank(message = "멘토링 팀 설명을 작성해 주세요")
     private String content;
-    private MentoringStatus status;
     @NotBlank(message = "연락방법을 작성해 주세요")
     private String link;
     @NotNull(message = "내 역할을 작성해 주세요")
@@ -34,13 +33,12 @@ public class RqTeamDto {
     private List<Long> categories;
 
     @Builder
-    public RqTeamDto(String name, LocalDate startDate, LocalDate endDate, int mentoringCnt, String content, MentoringStatus status, String link, MentoringRole role, List<Long> categories) {
+    public RqTeamDto(String name, LocalDate startDate, LocalDate endDate, int mentoringCnt, String content, String link, MentoringRole role, List<Long> categories) {
         this.name = name;
         this.startDate = startDate;
         this.endDate = endDate;
         this.mentoringCnt = mentoringCnt;
         this.content = content;
-        this.status = status;
         this.link = link;
         this.role = role;
         this.categories = categories;

--- a/src/main/java/com/project/Teaming/domain/mentoring/dto/response/RsBoardDto.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/dto/response/RsBoardDto.java
@@ -45,13 +45,14 @@ public class RsBoardDto {
         this.contents = contents;
     }
 
-    public RsBoardDto(Long id, String title, String mentoringTeamName, LocalDate startDate, LocalDate endDate, String contents) {
+    public RsBoardDto(Long id, String title, String mentoringTeamName, LocalDate startDate, LocalDate endDate, String contents, PostStatus status) {
         this.id = id;
         this.title = title;
         this.mentoringTeamName = mentoringTeamName;
         this.startDate = startDate;
         this.endDate = endDate;
         this.contents = contents;
+        this.status = status;
     }
 
     public static RsBoardDto from(MentoringBoard mentoringBoard, MentoringTeam mentoringTeam, List<String> categories) {

--- a/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringBoard.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringBoard.java
@@ -2,6 +2,7 @@ package com.project.Teaming.domain.mentoring.entity;
 
 import com.project.Teaming.domain.mentoring.dto.request.RqBoardDto;
 import com.project.Teaming.domain.mentoring.dto.response.RsSpecBoardDto;
+import com.project.Teaming.domain.user.entity.User;
 import com.project.Teaming.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -104,4 +105,10 @@ public class MentoringBoard extends BaseTimeEntity {
         mentoringTeam.getMentoringBoardList().add(this);
     }
 
+    public void removeMentoringBoard(MentoringTeam mentoringTeam) {
+        if (this.mentoringTeam != null) {
+            this.mentoringTeam.getMentoringBoardList().remove(this);
+            this.mentoringTeam = null;
+        }
+    }
 }

--- a/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringParticipation.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringParticipation.java
@@ -62,8 +62,6 @@ public class MentoringParticipation {
     }
 
 
-
-
     public void setParticipationStatus(MentoringParticipationStatus participationStatus) {
         this.participationStatus = participationStatus;
     }

--- a/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringStatus.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringStatus.java
@@ -2,5 +2,4 @@ package com.project.Teaming.domain.mentoring.entity;
 
 public enum MentoringStatus {
     RECRUITING, WORKING, COMPLETE
-
 }

--- a/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringTeam.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/entity/MentoringTeam.java
@@ -83,7 +83,6 @@ public class MentoringTeam extends BaseEntity {
                 .content(this.getContent())
                 .status(this.getStatus())
                 .link(this.getLink())
-                .status(this.getStatus())
                 .build();
         return dto;
     }
@@ -94,7 +93,6 @@ public class MentoringTeam extends BaseEntity {
         this.endDate = dto.getEndDate();
         this.mentoringCnt = dto.getMentoringCnt();
         this.content = dto.getContent();
-        this.status = dto.getStatus();
         this.link = dto.getLink();
     }
 }

--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/BoardRepositoryCustom.java
@@ -1,14 +1,7 @@
 package com.project.Teaming.domain.mentoring.repository;
 
-import com.project.Teaming.domain.mentoring.dto.response.RsBoardDto;
 import com.project.Teaming.domain.mentoring.entity.MentoringBoard;
-import com.project.Teaming.domain.mentoring.entity.MentoringStatus;
-import com.project.Teaming.domain.mentoring.entity.PostStatus;
 import com.project.Teaming.domain.mentoring.entity.Status;
-import com.querydsl.core.Tuple;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 import java.util.List;
 
 public interface BoardRepositoryCustom {

--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/BoardRepositoryCustomImpl.java
@@ -1,15 +1,9 @@
 package com.project.Teaming.domain.mentoring.repository;
 
-import com.project.Teaming.domain.mentoring.dto.response.RsBoardDto;
 import com.project.Teaming.domain.mentoring.entity.*;
-import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -58,7 +52,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
                 .join(tc.category, c).fetchJoin()
                 .where(mb.id.in(boardIds))
                 .orderBy(mb.createdDate.desc(),
-                        c.id.asc())             // Category 기준 정렬 추가)
+                        c.id.asc())             // Category 기준 정렬 추가
                 .fetch();
 
     }

--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringBoardRepository.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringBoardRepository.java
@@ -13,15 +13,14 @@ import java.util.List;
 
 public interface MentoringBoardRepository extends JpaRepository<MentoringBoard,Long>, BoardRepositoryCustom {
 
-    @Query("SELECT new com.project.Teaming.domain.mentoring.dto.response.RsBoardDto(pb.id, pb.title,mt.name, mt.startDate, mt.endDate, pb.contents) " +
-            "FROM MentoringBoard pb " +
-            "JOIN pb.mentoringTeam mt " +
+    @Query("SELECT new com.project.Teaming.domain.mentoring.dto.response.RsBoardDto(mb.id, mb.title,mt.name, mt.startDate, mt.endDate, mb.contents, mb.status) " +
+            "FROM MentoringBoard mb " +
+            "JOIN mb.mentoringTeam mt " +
             "WHERE mt.id = :teamId " +
-            "ORDER BY pb.createdDate desc")
+            "ORDER BY mb.createdDate desc")
     List<RsBoardDto> findAllByMentoringTeamId(@Param("teamId") Long teamId);
 
     /**
-     * 수정필요, n+1문제고려
      * @param teamId
      * @return
      */

--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringBoardRepository.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringBoardRepository.java
@@ -38,5 +38,8 @@ public interface MentoringBoardRepository extends JpaRepository<MentoringBoard,L
                           @Param("currentStatus") PostStatus currentStatus,
                           @Param("now") LocalDate now);
 
+    @Modifying
+    @Query("DELETE FROM MentoringBoard mb WHERE mb.mentoringTeam.id = :teamId")
+    void deleteByTeamId(@Param("teamId") Long teamId);
 
 }

--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringParticipationRepository.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringParticipationRepository.java
@@ -3,10 +3,7 @@ package com.project.Teaming.domain.mentoring.repository;
 import com.project.Teaming.domain.mentoring.dto.response.RsTeamParticipationDto;
 import com.project.Teaming.domain.mentoring.dto.response.RsTeamUserDto;
 import com.project.Teaming.domain.mentoring.dto.response.RsUserParticipationDto;
-import com.project.Teaming.domain.mentoring.entity.MentoringAuthority;
-import com.project.Teaming.domain.mentoring.entity.MentoringParticipation;
-import com.project.Teaming.domain.mentoring.entity.MentoringParticipationStatus;
-import com.project.Teaming.domain.mentoring.entity.MentoringTeam;
+import com.project.Teaming.domain.mentoring.entity.*;
 import com.project.Teaming.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -38,12 +35,8 @@ public interface MentoringParticipationRepository extends JpaRepository<Mentorin
             "where mt.id = :teamId and mp.id <> :id and mp.participationStatus <> :status")
     List<RsUserParticipationDto> findAllForUser(@Param("teamId") Long teamId, @Param("id") Long leader_id, @Param("status") MentoringParticipationStatus status);
 
-    @Query("select mp " +
-            "from MentoringParticipation mp " +
-            "join fetch mp.mentoringTeam mt " +
-            "join fetch mp.user u " +
-            "where mt = :mentoringTeam and u = :user and mp.authority = :authority")
-    Optional<MentoringParticipation> findByMentoringTeamAndUserAndAuthority(@Param("mentoringTeam") MentoringTeam mentoringTeam, @Param("user") User user, @Param("authority") MentoringAuthority authority);
+
+    Optional<MentoringParticipation> findByMentoringTeamAndUserAndAuthority(MentoringTeam mentoringTeam, User user, MentoringAuthority authority);
 
     @Query("select mp " +
     "from MentoringParticipation mp " +
@@ -52,7 +45,7 @@ public interface MentoringParticipationRepository extends JpaRepository<Mentorin
     "where mt = :mentoringTeam and u = :user")
     Optional<MentoringParticipation> findByMentoringTeamAndUser(@Param("mentoringTeam") MentoringTeam mentoringTeam, @Param("user") User user);
 
-    @Query("SELECT mp FROM MentoringParticipation mp JOIN FETCH mp.mentoringTeam mt " +
+    @Query("SELECT mp FROM MentoringParticipation mp JOIN mp.mentoringTeam mt " +
             "WHERE mt.id = :teamId AND mp.isDeleted = false AND mp.participationStatus = :participationStatus AND mp.authority = :authority " +
             "ORDER BY mp.decisionDate ASC")
     List<MentoringParticipation> findTeamUsers(
@@ -61,10 +54,14 @@ public interface MentoringParticipationRepository extends JpaRepository<Mentorin
             @Param("authority") MentoringAuthority authority);
 
 
-    @Query("select mp " +
-            "from MentoringParticipation mp " +
-            "join fetch mp.mentoringTeam mt " +
-            "join fetch mp.user u " +
-            "where mt = :mentoringTeam and u = :user and mp.participationStatus = :status")
-    Optional<MentoringParticipation> findByMentoringTeamAndUserAndParticipationStatus(@Param("mentoringTeam") MentoringTeam mentoringTeam, @Param("user") User user, @Param("status") MentoringParticipationStatus status);
+    Optional<MentoringParticipation> findByMentoringTeamAndUserAndParticipationStatus(MentoringTeam mentoringTeam, User user, MentoringParticipationStatus status);
+
+    @Query("SELECT mp FROM MentoringParticipation mp " +
+            "JOIN FETCH mp.mentoringTeam mt " +
+            "WHERE mp.user = :user AND mp.participationStatus = :status AND mp.isDeleted = false AND mt.flag != :flag")
+    List<MentoringParticipation> findParticipationsWithTeamsAndUser(
+            @Param("user") User user,
+            @Param("status") MentoringParticipationStatus status,
+            @Param("flag") Status flag);
+
 }

--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringTeamRepository.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/MentoringTeamRepository.java
@@ -11,4 +11,7 @@ import java.util.Optional;
 
 public interface MentoringTeamRepository extends JpaRepository<MentoringTeam,Long> {
 
+    @Query("SELECT t FROM MentoringTeam t JOIN FETCH t.mentoringBoardList WHERE t.id = :teamId")
+    Optional<MentoringTeam> findWithBoardsById(@Param("teamId") Long teamId);
+
 }

--- a/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringBoardService.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringBoardService.java
@@ -223,7 +223,7 @@ public class MentoringBoardService {
     }
 
     /**
-     * 리더가 글에서 모집 현황을 수정할 수 있는 로직
+     * 팀원이 글에서 모집 현황을 수정할 수 있는 로직
      * @param teamId
      * @param postId
      * @return
@@ -232,9 +232,9 @@ public class MentoringBoardService {
     public MentoringPostStatusDto updatePostStatus(Long teamId, Long postId) {
         User user = getUser();
         MentoringTeam mentoringTeam = mentoringTeamRepository.findById(teamId).orElseThrow(MentoringTeamNotFoundException::new);
-        Optional<MentoringParticipation> teamLeader = mentoringParticipationRepository.findByMentoringTeamAndUserAndAuthority(mentoringTeam, user, MentoringAuthority.LEADER);
+        Optional<MentoringParticipation> teamUser = mentoringParticipationRepository.findByMentoringTeamAndUserAndParticipationStatus(mentoringTeam, user, MentoringParticipationStatus.ACCEPTED);
         MentoringBoard post = mentoringBoardRepository.findById(postId).orElseThrow(MentoringPostNotFoundException::new);
-        if (teamLeader.isPresent()) {
+        if (teamUser.isPresent() && !teamUser.get().getIsDeleted()) {
             post.updateStatus();
             return new MentoringPostStatusDto(PostStatus.COMPLETE);
         } else {

--- a/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringParticipationService.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringParticipationService.java
@@ -5,7 +5,6 @@ import com.project.Teaming.domain.mentoring.dto.response.*;
 import com.project.Teaming.domain.mentoring.entity.*;
 import com.project.Teaming.domain.mentoring.repository.MentoringParticipationRepository;
 import com.project.Teaming.domain.mentoring.repository.MentoringTeamRepository;
-import com.project.Teaming.domain.project.entity.ParticipationStatus;
 import com.project.Teaming.domain.user.entity.User;
 import com.project.Teaming.domain.user.repository.UserRepository;
 import com.project.Teaming.global.error.ErrorCode;
@@ -36,14 +35,12 @@ public class MentoringParticipationService {
 
     /**
      * 지원자로 등록하는 로직
-     * @param mentoringTeamId
      * @param dto
      * @return
      */
     @Transactional
-    public Long saveMentoringParticipation(Long mentoringTeamId, RqParticipationDto dto) {
+    public Long saveMentoringParticipation(MentoringTeam mentoringTeam, RqParticipationDto dto) {
         User user = getUser();
-        MentoringTeam mentoringTeam = mentoringTeamRepository.findById(mentoringTeamId).orElseThrow(MentoringTeamNotFoundException::new);
         Optional<MentoringParticipation> participation = mentoringParticipationRepository.findByMentoringTeamAndUser(mentoringTeam, user);
         if (participation.isPresent()) {
             if (participation.get().getParticipationStatus() == MentoringParticipationStatus.ACCEPTED) {
@@ -184,7 +181,6 @@ public class MentoringParticipationService {
                 firstMember.ifPresentOrElse(
                         participation -> {
                             participation.setAuthority(MentoringAuthority.LEADER);
-                            log.info("New team leader set: {}", participation.getUser().getId());
                         },
                         () -> {
                             throw new BusinessException(ErrorCode.NO_ELIGIBLE_MEMBER_FOR_LEADER);

--- a/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringTeamService.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringTeamService.java
@@ -1,5 +1,6 @@
 package com.project.Teaming.domain.mentoring.service;
 
+import com.project.Teaming.domain.mentoring.dto.request.RqParticipationDto;
 import com.project.Teaming.domain.mentoring.dto.request.RqTeamDto;
 import com.project.Teaming.domain.mentoring.dto.response.MyTeamDto;
 import com.project.Teaming.domain.mentoring.dto.response.TeamResponseDto;
@@ -39,8 +40,8 @@ public class MentoringTeamService {
 
     private final MentoringTeamRepository mentoringTeamRepository;
     private final UserRepository userRepository;
-    private final CategoryRepository categoryRepository;
-    private final TeamCategoryRepository teamCategoryRepository;
+    private final TeamCategoryService teamCategoryService;
+    private final MentoringParticipationService mentoringParticipationService;
     private final MentoringParticipationRepository mentoringParticipationRepository;
     private final MentoringBoardRepository mentoringBoardRepository;
 
@@ -64,18 +65,12 @@ public class MentoringTeamService {
                 .build();
 
         MentoringTeam saved = mentoringTeamRepository.save(mentoringTeam);
+        //리더 생성
+        RqParticipationDto participationDto = new RqParticipationDto(MentoringAuthority.LEADER, MentoringParticipationStatus.ACCEPTED, dto.getRole());
+        mentoringParticipationService.saveMentoringParticipation(mentoringTeam, participationDto);
 
         //카테고리 생성
-        List<Long> categoryIds = dto.getCategories();
-        List<Category> categories = categoryRepository.findAllById(categoryIds);
-
-        //연관관계 매핑
-        for (Category category : categories) {
-            TeamCategory teamCategory = new TeamCategory();
-            teamCategory.setCategory(category);
-            teamCategory.setMentoringTeam(mentoringTeam);
-            teamCategoryRepository.save(teamCategory);
-        }
+        teamCategoryService.saveTeamCategories(saved,dto.getCategories());
         return saved.getId();
     }
 
@@ -94,32 +89,10 @@ public class MentoringTeamService {
         }
         if (teamLeader.isPresent() && !teamLeader.get().getIsDeleted()) {
             mentoringTeam.mentoringTeamUpdate(dto); //업데이트 메서드
-            List<TeamCategory> categoriesToRemove = new ArrayList<>(mentoringTeam.getCategories()); // 리스트 복사,객체 참조
-            // 연관관계 해제
-            for (TeamCategory teamCategory : categoriesToRemove) {
-                teamCategory.removeCategory(teamCategory.getCategory());  // 팀 카테고리 연관관계 해제
-                teamCategory.removeMentoringTeam(mentoringTeam);          // 멘토링 팀 연관관계 해제
-            }
-
-            // 팀에서 TeamCategory 컬렉션 초기화(안정성 보장)
-            mentoringTeam.getCategories().clear();
-
-            // TeamCategory 삭제
-            for (TeamCategory teamCategory : categoriesToRemove) {
-                teamCategoryRepository.delete(teamCategory);
-            }
-
-            //업데이트 될 카테고리들
-            List<Long> categoriesId = dto.getCategories();
-            List<Category> updateCategories = categoryRepository.findAllById(categoriesId);
-            //연관관계 매핑
-            for (Category category : updateCategories) {
-                TeamCategory teamCategory = new TeamCategory();
-                teamCategory.setCategory(category);
-                teamCategory.setMentoringTeam(mentoringTeam);
-                teamCategoryRepository.save(teamCategory);
-            }
-
+            // 기존 카테고리 제거
+            teamCategoryService.removeTeamCategories(mentoringTeam);
+            // 새로운 카테고리 매핑
+            teamCategoryService.saveTeamCategories(mentoringTeam, dto.getCategories());
         }
         else throw new NoAuthorityException("수정 할 권한이 없습니다");
     }
@@ -144,14 +117,14 @@ public class MentoringTeamService {
      */
     public List<MentoringTeam> findMyMentoringTeams() {
         User user = getUser();
-        List<MentoringTeam> teams = new ArrayList<>();
-        List<MentoringParticipation> mentoringParticipants = user.getMentoringParticipations();
-        for (MentoringParticipation x : mentoringParticipants) {
-            if (x.getParticipationStatus() == MentoringParticipationStatus.ACCEPTED && !x.getIsDeleted()) {
-                teams.add(x.getMentoringTeam());
-            }
-        }
-        return teams;
+        List<MentoringParticipation> participations = mentoringParticipationRepository.findParticipationsWithTeamsAndUser(
+                user,
+                MentoringParticipationStatus.ACCEPTED,
+                Status.TRUE
+        );
+        return participations.stream()
+                .map(MentoringParticipation::getMentoringTeam)
+                .toList();
     }
 
 

--- a/src/main/java/com/project/Teaming/domain/mentoring/service/TeamCategoryService.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/service/TeamCategoryService.java
@@ -1,0 +1,51 @@
+package com.project.Teaming.domain.mentoring.service;
+
+import com.project.Teaming.domain.mentoring.entity.Category;
+import com.project.Teaming.domain.mentoring.entity.MentoringTeam;
+import com.project.Teaming.domain.mentoring.entity.TeamCategory;
+import com.project.Teaming.domain.mentoring.repository.CategoryRepository;
+import com.project.Teaming.domain.mentoring.repository.MentoringTeamRepository;
+import com.project.Teaming.domain.mentoring.repository.TeamCategoryRepository;
+import com.project.Teaming.global.error.exception.MentoringTeamNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamCategoryService {
+
+    private final TeamCategoryRepository teamCategoryRepository;
+    private final CategoryRepository categoryRepository;
+
+
+    @Transactional
+    public void saveTeamCategories(MentoringTeam mentoringTeam, List<Long> categoryIds) {
+        List<Category> categories = categoryRepository.findAllById(categoryIds);
+
+        //연관관계 매핑
+        for (Category category : categories) {
+            TeamCategory teamCategory = new TeamCategory();
+            teamCategory.setCategory(category);
+            teamCategory.setMentoringTeam(mentoringTeam);
+            teamCategoryRepository.save(teamCategory);
+        }
+    }
+
+    @Transactional
+    public void removeTeamCategories(MentoringTeam mentoringTeam) {
+        List<TeamCategory> categoriesToRemove = new ArrayList<>(mentoringTeam.getCategories());
+        for (TeamCategory teamCategory : categoriesToRemove) {
+            teamCategory.removeCategory(teamCategory.getCategory());
+            teamCategory.removeMentoringTeam(mentoringTeam);
+            mentoringTeam.getCategories().remove(teamCategory);  //안정성 보장
+            teamCategoryRepository.delete(teamCategory);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 연관된 이슈 
#125 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
TeamCategory관련된 로직을 분리하고 team 수정시 mentoringStatus컬럼을 삭제함
