### PR TITLE
팀장 탈퇴 시, 팀장 권한 이전 기능 추가

### DIFF
--- a/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
+++ b/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
@@ -126,4 +126,8 @@ public class ProjectParticipation {
     public void exportTeam() {
         this.isExport = true;
     }
+
+    public void setRole(ProjectRole role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
+++ b/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
@@ -6,6 +6,8 @@ import com.project.Teaming.domain.project.entity.ProjectRole;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectParticipationRepository extends JpaRepository<ProjectParticipation, Long> {
 
@@ -24,4 +26,13 @@ public interface ProjectParticipationRepository extends JpaRepository<ProjectPar
     Optional<ProjectParticipation> findByProjectTeamIdAndUserIdAndParticipationStatus(Long projectId, Long userId, ParticipationStatus status);
 
     long countByProjectTeamIdAndParticipationStatusAndIsDeleted(Long teamId, ParticipationStatus status, boolean delete);
+
+    @Query("SELECT pp FROM ProjectParticipation pp JOIN pp.projectTeam pt "
+            + "WHERE pt.id = :teamId AND pp.isDeleted = false AND pp.participationStatus = :participationStatus AND pp.role = :role "
+            + "ORDER BY pp.decisionDate ASC ")
+    List<ProjectParticipation> findTeamUsers(
+            @Param("teamId") Long teamId,
+            @Param("participationStatus") ParticipationStatus participationStatus,
+            @Param("role") ProjectRole role
+    );
 }

--- a/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
+++ b/src/main/java/com/project/Teaming/domain/project/repository/ProjectParticipationRepository.java
@@ -15,7 +15,7 @@ public interface ProjectParticipationRepository extends JpaRepository<ProjectPar
 
     List<ProjectParticipation> findByProjectTeamId(Long teamId);
 
-    boolean existsByProjectTeamIdAndUserIdAndParticipationStatus(Long projectTeamId, Long userID, ParticipationStatus status);
+    boolean existsByProjectTeamIdAndUserIdAndParticipationStatusAndIsDeleted(Long projectTeamId, Long userID, ParticipationStatus status, boolean isDeleted);
 
     Optional<ProjectParticipation> findByProjectTeamIdAndRole(Long projectId, ProjectRole role);
 

--- a/src/main/java/com/project/Teaming/domain/project/service/ProjectBoardService.java
+++ b/src/main/java/com/project/Teaming/domain/project/service/ProjectBoardService.java
@@ -55,8 +55,8 @@ public class ProjectBoardService {
         User user = userRepository.findById(getCurrentId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
 
-        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatus(teamId, user.getId(),
-                ParticipationStatus.ACCEPTED);
+        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatusAndIsDeleted(teamId, user.getId(),
+                ParticipationStatus.ACCEPTED, false);
         if (!isMember) {
             throw new BusinessException(ErrorCode.USER_NOT_PART_OF_TEAM);
         }
@@ -93,8 +93,8 @@ public class ProjectBoardService {
         User user = userRepository.findById(getCurrentId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
 
-        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatus(teamId, user.getId(),
-                ParticipationStatus.ACCEPTED);
+        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatusAndIsDeleted(teamId, user.getId(),
+                ParticipationStatus.ACCEPTED, false);
         if (!isMember) {
             throw new BusinessException(ErrorCode.USER_NOT_PART_OF_TEAM);
         }
@@ -108,8 +108,8 @@ public class ProjectBoardService {
         User user = userRepository.findById(getCurrentId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
 
-        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatus(teamId, user.getId(),
-                ParticipationStatus.ACCEPTED);
+        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatusAndIsDeleted(teamId, user.getId(),
+                ParticipationStatus.ACCEPTED, false);
         if (!isMember) {
             throw new BusinessException(ErrorCode.USER_NOT_PART_OF_TEAM);
         }
@@ -161,8 +161,8 @@ public class ProjectBoardService {
         User user = userRepository.findById(getCurrentId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
 
-        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatus(teamId, user.getId(),
-                ParticipationStatus.ACCEPTED);
+        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatusAndIsDeleted(teamId, user.getId(),
+                ParticipationStatus.ACCEPTED, false);
         if (!isMember) {
             throw new BusinessException(ErrorCode.USER_NOT_PART_OF_TEAM);
         }

--- a/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
+++ b/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
@@ -184,8 +184,8 @@ public class ProjectParticipationService {
         List<ProjectParticipation> teamMembers = projectParticipationRepository.findByProjectTeamIdAndParticipationStatus(teamId, ParticipationStatus.ACCEPTED);
 
         // 팀의 멤버인지 판별
-        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatus(teamId, user.getId(),
-                ParticipationStatus.ACCEPTED);
+        boolean isMember = projectParticipationRepository.existsByProjectTeamIdAndUserIdAndParticipationStatusAndIsDeleted(teamId, user.getId(),
+                ParticipationStatus.ACCEPTED, false);
         if (!isMember) {
             throw new BusinessException(ErrorCode.USER_NOT_PART_OF_TEAM);
         }


### PR DESCRIPTION
## 📌 연관된 이슈 
<!-- 이슈 번호를 작성해주세요. ex) #이슈번호, ... -->
#141 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- [x] 팀장 탈퇴 시, 팀장 권한 이전 기능 추가
- [x] 탈퇴한 팀원은 팀에 접근 못하도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
