### PR TITLE
fix: 팀장 중복 조회 에러 수정

### DIFF
--- a/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
+++ b/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
@@ -131,4 +131,8 @@ public class ProjectParticipation {
     public void setRole(ProjectRole role) {
         this.role = role;
     }
+
+    public void updateOwnerRole() {
+        this.role = ProjectRole.MEMBER;
+    }
 }

--- a/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
+++ b/src/main/java/com/project/Teaming/domain/project/entity/ProjectParticipation.java
@@ -1,7 +1,6 @@
 package com.project.Teaming.domain.project.entity;
 
 import com.project.Teaming.domain.user.entity.Report;
-import com.project.Teaming.domain.user.entity.Review;
 import com.project.Teaming.domain.user.entity.User;
 import com.project.Teaming.global.error.ErrorCode;
 import com.project.Teaming.global.error.exception.BusinessException;
@@ -63,16 +62,18 @@ public class ProjectParticipation {
     private List<Report> reports = new ArrayList<>();  // 신고 테이블과 일대다
 
 
-    public void createProjectParticipation(User user, ProjectTeam team) {
-        this.participationStatus = ParticipationStatus.ACCEPTED;
-        this.isDeleted = false;
-        this.isExport = false;
-        this.requestDate = LocalDateTime.now();
-        this.decisionDate = LocalDateTime.now();
-        this.role = ProjectRole.OWNER;
-        this.recruitCategory = "OWNER";
-        this.user = user;
-        this.projectTeam = team;
+    public static ProjectParticipation create(User user, ProjectTeam team) {
+        ProjectParticipation projectParticipation = new ProjectParticipation();
+        projectParticipation.participationStatus = ParticipationStatus.ACCEPTED;
+        projectParticipation.isDeleted = false;
+        projectParticipation.isExport = false;
+        projectParticipation.requestDate = LocalDateTime.now();
+        projectParticipation.decisionDate = LocalDateTime.now();
+        projectParticipation.role = ProjectRole.OWNER;
+        projectParticipation.recruitCategory = "OWNER";
+        projectParticipation.user = user;
+        projectParticipation.projectTeam = team;
+        return projectParticipation;
     }
 
     public void joinTeamMember(User user, ProjectTeam projectTeam, String recruitCategory) {

--- a/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
+++ b/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
@@ -105,6 +105,7 @@ public class ProjectParticipationService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_PARTICIPATION));
 
         if (projectParticipation.canQuit()) {
+            // 팀장이 탈퇴 시
             if (projectParticipation.getRole().equals(ProjectRole.OWNER)) {
                 Optional<ProjectParticipation> firstMember = projectParticipationRepository.findTeamUsers(teamId, ParticipationStatus.ACCEPTED, ProjectRole.MEMBER)
                         .stream().findFirst();
@@ -116,6 +117,7 @@ public class ProjectParticipationService {
                             throw new BusinessException(ErrorCode.NO_ELIGIBLE_MEMBER_FOR_LEADER);
                         }
                 );
+                projectParticipation.updateOwnerRole();
             }
             projectParticipation.quitTeam();
         } else {

--- a/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
+++ b/src/main/java/com/project/Teaming/domain/project/service/ProjectParticipationService.java
@@ -43,12 +43,14 @@ public class ProjectParticipationService {
     private final ReviewRepository reviewRepository;
 
     public void createParticipation(ProjectTeam projectTeam) {
-        ProjectParticipation projectParticipation = new ProjectParticipation();
-        User user = userRepository.findById(getCurrentId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
-
-        projectParticipation.createProjectParticipation(user, projectTeam);
+        User user = getLoginUser();
+        ProjectParticipation projectParticipation = ProjectParticipation.create(user, projectTeam);
         projectParticipationRepository.save(projectParticipation);
+    }
+
+    private User getLoginUser() {
+        return userRepository.findById(getCurrentId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
     }
 
     private Long getCurrentId() {

--- a/src/main/java/com/project/Teaming/domain/project/service/ProjectTeamService.java
+++ b/src/main/java/com/project/Teaming/domain/project/service/ProjectTeamService.java
@@ -8,7 +8,6 @@ import com.project.Teaming.domain.project.dto.response.ProjectTeamInfoDto;
 import com.project.Teaming.domain.project.entity.ParticipationStatus;
 import com.project.Teaming.domain.project.entity.ProjectParticipation;
 import com.project.Teaming.domain.project.entity.ProjectRole;
-import com.project.Teaming.domain.project.entity.ProjectStatus;
 import com.project.Teaming.domain.project.entity.ProjectTeam;
 import com.project.Teaming.domain.project.entity.RecruitCategory;
 import com.project.Teaming.domain.project.entity.Stack;
@@ -25,8 +24,6 @@ import com.project.Teaming.domain.user.repository.UserRepository;
 import com.project.Teaming.global.error.ErrorCode;
 import com.project.Teaming.global.error.exception.BusinessException;
 import com.project.Teaming.global.jwt.dto.SecurityUserDto;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -90,8 +87,7 @@ public class ProjectTeamService {
     }
 
     public ProjectTeamInfoDto getTeam(Long teamId) {
-        ProjectTeam projectTeam = projectTeamRepository.findById(teamId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_TEAM));
+        ProjectTeam projectTeam = findProjectTeamById(teamId);
 
         // 기술 스택 id 리스트 생성
         List<String> stackIds = projectTeam.getStacks().stream()
@@ -106,9 +102,10 @@ public class ProjectTeamService {
         return ProjectTeamInfoDto.from(projectTeam, stackIds, recruitCategoryIds);
     }
 
+
+
     public void editTeam(Long teamId, UpdateTeamDto dto) {
-        ProjectTeam projectTeam = projectTeamRepository.findById(teamId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_TEAM));
+        ProjectTeam projectTeam = findProjectTeamById(teamId);
 
         List<Stack> stacks = stackRepository.findAllById(dto.getStackIds());
         List<Long> missingStackIds = dto.getStackIds().stream()
@@ -132,8 +129,7 @@ public class ProjectTeamService {
     }
 
     public void deleteTeam(Long teamId) {
-        ProjectTeam projectTeam = projectTeamRepository.findById(teamId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_TEAM));
+        ProjectTeam projectTeam = findProjectTeamById(teamId);
 
         projectTeamRepository.delete(projectTeam);
     }
@@ -143,8 +139,7 @@ public class ProjectTeamService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_USER));
         ProjectParticipation teamOwner = projectParticipationRepository.findByProjectTeamIdAndRole(dto.getTeamId(), ProjectRole.OWNER)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_OWNER));
-        ProjectTeam projectTeam = projectTeamRepository.findById(dto.getTeamId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_TEAM));
+        ProjectTeam projectTeam = findProjectTeamById(dto.getTeamId());
 
         if (user.getId().equals(teamOwner.getUser().getId())) {
             projectTeam.updateTeamStatus(dto.getStatus());
@@ -173,5 +168,10 @@ public class ProjectTeamService {
                 })
                 .collect(Collectors.toList());
         return projectLists;
+    }
+
+    private ProjectTeam findProjectTeamById(Long teamId) {
+        return projectTeamRepository.findById(teamId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PROJECT_TEAM));
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈 
<!-- 이슈 번호를 작성해주세요. ex) #이슈번호, ... -->
#164 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- [x] 팀장 조회 시, 중복 조회 에러 수정
  ```java
  // JPA에서 쿼리를 수행했을 때, 결과가 유일해야 하는 상황에서 2개의 결과가 반환됨.
  org.springframework.dao.IncorrectResultSizeDataAccessException: Query did not return a unique result: 2 results were returned
  ```
- [x] 중복 코드 제거 및 메서드, 역할 분리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
