### PR TITLE
feat: 팀원 및 지원자현황 반환 dto에 리뷰 여부 데이터 추가 #125

### DIFF
--- a/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringParticipationController.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringParticipationController.java
@@ -36,8 +36,8 @@ public class MentoringParticipationController {
         MentoringBoard mentoringPost = mentoringBoardService.findMentoringPost(post_id);
         MentoringTeam mentoringTeam = mentoringPost.getMentoringTeam();
         RqParticipationDto participationDto = new RqParticipationDto(MentoringAuthority.NoAuth, MentoringParticipationStatus.PENDING, mentoringPost.getRole());
-        Long id = mentoringParticipationService.saveMentoringParticipation(mentoringTeam, participationDto);
-        return new ResultDetailResponse<>(ResultCode.REGISTER_MENTORING_PARTICIPATION, String.valueOf(id));
+        MentoringParticipation participation = mentoringParticipationService.saveMentoringParticipation(mentoringTeam, participationDto);
+        return new ResultDetailResponse<>(ResultCode.REGISTER_MENTORING_PARTICIPATION, String.valueOf(participation.getId()));
     }
 
     @DeleteMapping("/teams/{team_id}/participants")
@@ -90,7 +90,7 @@ public class MentoringParticipationController {
         return new ResultDetailResponse<>(ResultCode.REVIEW_TEAM_USER, null);
     }
 
-    @GetMapping("/mentoring/teams/{team_id}/status")
+    @GetMapping("/teams/{team_id}/status")
     @Operation(summary = "멘토링팀 멤버 및 지원자 현황 조회", description = "멘토링 팀 멤버나 지원자 현황을 조회하는 API " +
             "조회하는 사람이 팀장이면 팀원과 지원자 정보 반환, 팀원이면 팀원 정보만 반환. " +
             "리더용, 팀원용 페이지에서 팀원 조회 시 isDeleted는 탈퇴 유무, isLogined는 현재 로그인 된 사용자 유무, status가 EXPORT면 강퇴된 사용자 입니다, " +

--- a/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringTeamController.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/controller/MentoringTeamController.java
@@ -3,6 +3,7 @@ package com.project.Teaming.domain.mentoring.controller;
 import com.project.Teaming.domain.mentoring.dto.request.RqTeamDto;
 import com.project.Teaming.domain.mentoring.dto.response.MyTeamDto;
 import com.project.Teaming.domain.mentoring.dto.response.TeamResponseDto;
+import com.project.Teaming.domain.mentoring.entity.MentoringStatus;
 import com.project.Teaming.domain.mentoring.entity.MentoringTeam;
 import com.project.Teaming.domain.mentoring.service.MentoringTeamService;
 import com.project.Teaming.global.result.ResultCode;
@@ -47,16 +48,6 @@ public class MentoringTeamController {
         TeamResponseDto teamDto = mentoringTeamService.getMentoringTeam(mentoringTeam);
 
         return new ResultDetailResponse<>(ResultCode.UPDATE_MENTORING_TEAM, teamDto);
-    }
-
-    @GetMapping("/teams")
-    @Operation(summary = "나의 모든 멘토링 팀 조회", description = "나의 모든 멘토링 팀을 조회할 수 있다. 마이페이지에서 사용")
-    public ResultListResponse<MyTeamDto> findMyMentoringTeams() {
-        List<MentoringTeam> myMentoringTeams = mentoringTeamService.findMyMentoringTeams();
-        List<MyTeamDto> teams = myMentoringTeams.stream()
-                .map(mentoringTeamService::getMyTeam)
-                .collect(Collectors.toList());
-        return new ResultListResponse<>(ResultCode.GET_MY_ALL_MENTORING_TEAM, teams);
     }
 
     @GetMapping("/teams/{team_id}")

--- a/src/main/java/com/project/Teaming/domain/mentoring/dto/response/ParticipantsDto.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/dto/response/ParticipantsDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ParticipantsDto<T> {
-    private T details;
-    private MentoringAuthority authority;
 
+    private MentoringAuthority authority;
+    private T details;
 }

--- a/src/main/java/com/project/Teaming/domain/mentoring/dto/response/RsTeamUserDto.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/dto/response/RsTeamUserDto.java
@@ -1,5 +1,6 @@
 package com.project.Teaming.domain.mentoring.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.project.Teaming.domain.mentoring.entity.MentoringParticipationStatus;
 import com.project.Teaming.domain.mentoring.entity.MentoringRole;
 import lombok.Data;
@@ -16,9 +17,12 @@ public class RsTeamUserDto {
     private MentoringParticipationStatus status;
     private Boolean isLogined;
     private Boolean isDeleted;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean isReviewed; // MentoringStatus가 COMPLETE일 때만 값 설정
 
-
-    public RsTeamUserDto(LocalDateTime acceptedTime, Long userId, String username, MentoringRole role, MentoringParticipationStatus status, Boolean isDeleted) {
+    // 기본 생성자 (isReviewed를 null로 설정)
+    public RsTeamUserDto(LocalDateTime acceptedTime, Long userId, String username,
+                         MentoringRole role, MentoringParticipationStatus status, Boolean isDeleted) {
         this.acceptedTime = acceptedTime;
         this.userId = userId;
         this.username = username;
@@ -26,5 +30,17 @@ public class RsTeamUserDto {
         this.status = status;
         this.isLogined = false;
         this.isDeleted = isDeleted;
+        this.isReviewed = null; // 기본값 null
+    }
+
+    public RsTeamUserDto(LocalDateTime acceptedTime, Long userId, String username, MentoringRole role, MentoringParticipationStatus status, Boolean isDeleted, Boolean isReviewed) {
+        this.acceptedTime = acceptedTime;
+        this.userId = userId;
+        this.username = username;
+        this.role = role;
+        this.status = status;
+        this.isLogined = false;
+        this.isDeleted = isDeleted;
+        this.isReviewed = (isReviewed != null) ? isReviewed : null; // 기본값 설정
     }
 }

--- a/src/main/java/com/project/Teaming/domain/user/controller/UserController.java
+++ b/src/main/java/com/project/Teaming/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.project.Teaming.domain.user.controller;
 
+import com.project.Teaming.domain.mentoring.dto.response.MyTeamDto;
+import com.project.Teaming.domain.mentoring.entity.MentoringTeam;
+import com.project.Teaming.domain.mentoring.service.MentoringTeamService;
 import com.project.Teaming.domain.user.dto.request.RegisterDto;
 import com.project.Teaming.domain.user.dto.request.UpdateUserInfoDto;
 import com.project.Teaming.domain.user.dto.response.ReviewDto;
@@ -21,6 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -29,6 +33,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final MentoringTeamService mentoringTeamService;
 
     @PostMapping("/user")
     @Operation(summary = "추가 정보 기입", description = "첫 로그인 후 추가 정보 기입할 때(또는 추가 정보 기입이 안되어 있을 때) 사용하는 Api. 닉네임은 필수, 소개와 기술스택은 선택")
@@ -38,7 +43,7 @@ public class UserController {
     }
 
     @GetMapping("/user")
-    @Operation(summary = "회원 정보 조회", description = "회원 정보(이메일, 이름, 가입경로, 포트폴리오, 경고누적횟수) 조회하는 Api(AccessToken 기입 필요) " +
+    @Operation(summary = "로그인 된 사용자 정보 조회", description = "회원 정보(이메일, 이름, 가입경로, 포트폴리오, 경고누적횟수) 조회하는 Api(AccessToken 기입 필요) " +
             "마이페이지에서 사용 " )
     public ResultDetailResponse<UserInfoDto> getUserInfo() {
         UserInfoDto userInfo = userService.getAuthenticatedUserInfo();
@@ -53,7 +58,7 @@ public class UserController {
     }
 
     @GetMapping("/user/reviews")
-    @Operation(summary = "사용자의 리뷰 조회", description = "해당 사용자의 리뷰를 가져온다, 마이페이지에서 사용")
+    @Operation(summary = "로그인 된 사용자의 리뷰 조회", description = "해당 사용자의 리뷰를 가져온다, 마이페이지에서 사용")
     public ResultListResponse<ReviewDto> getReviews() {
         List<ReviewDto> reviews = userService.getAuthenticatedUserReviews();
         return new ResultListResponse<>(ResultCode.GET_USER_REVIEWS, reviews);
@@ -67,7 +72,7 @@ public class UserController {
     }
 
     @GetMapping("/user/my-page/report")
-    @Operation(summary = "사용자의 경고 횟수 조회", description = "특정유저의 경고 누적 횟수를 조회하는 API")
+    @Operation(summary = "로그인 된 사용자의 경고 횟수 조회", description = "특정유저의 경고 누적 횟수를 조회하는 API")
     public ResultDetailResponse<UserReportCnt> userReportInfo() {
         UserReportCnt cnt = userService.getWarningCnt();
         return new ResultDetailResponse<>(ResultCode.GET_USER_WARNING_CNT, cnt);
@@ -78,6 +83,26 @@ public class UserController {
     public ResultDetailResponse<Void> updateUser(@Valid @RequestBody UpdateUserInfoDto updateUserInfoDto) {
         userService.updateUser(updateUserInfoDto);
         return new ResultDetailResponse<>(ResultCode.UPDATE_USER_INFO, null);
+    }
+
+    @GetMapping("/user/mentoring/teams")
+    @Operation(summary = "로그인 된 사용자의 모든 멘토링 팀 조회", description = "나의 모든 멘토링 팀을 조회할 수 있다. 마이페이지에서 사용")
+    public ResultListResponse<MyTeamDto> findMyMentoringTeams() {
+        List<MentoringTeam> myMentoringTeams = mentoringTeamService.getAuthenticateTeams();
+        List<MyTeamDto> teams = myMentoringTeams.stream()
+                .map(mentoringTeamService::getMyTeam)
+                .collect(Collectors.toList());
+        return new ResultListResponse<>(ResultCode.GET_MY_ALL_MENTORING_TEAM, teams);
+    }
+
+    @GetMapping("/users/{user_id}/mentoring/teams")
+    @Operation(summary = "유저의 모든 멘토링 팀 조회", description = "유저의 모든 멘토링 팀을 조회할 수 있다. 유저페이지에서 사용")
+    public ResultListResponse<MyTeamDto> findUserMentoringTeams(@PathVariable Long user_id) {
+        List<MentoringTeam> myMentoringTeams = mentoringTeamService.findMyMentoringTeams(user_id);
+        List<MyTeamDto> teams = myMentoringTeams.stream()
+                .map(mentoringTeamService::getMyTeam)
+                .collect(Collectors.toList());
+        return new ResultListResponse<>(ResultCode.GET_ALL_USER_MENTORING_TEAM, teams);
     }
 
 }

--- a/src/main/java/com/project/Teaming/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/Teaming/global/config/SecurityConfig.java
@@ -54,8 +54,7 @@ public class SecurityConfig {
                         .requestMatchers("/token/**").permitAll() // 토큰 발급 경로 허용
                         .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/login",
                                 "/project/team/{team_id}", "/project/team/{team_id}/participations", "/project/post/{post_id}",
-                                "/project/posts","/mentoring/posts","/mentoring/team/{team_Id}","/mentoring/post/{post_id}","/mock/**",
-                                "/mentoring/categories/**").permitAll() // 특정 경로 허용
+                                "/project/posts","/mentoring/posts","/mentoring/teams/{team_Id}","/mentoring/posts/{post_id}","/mock/**").permitAll() // 특정 경로 허용
                         .anyRequest().authenticated() // 그 외 모든 요청 인증 필요
                 );
 

--- a/src/main/java/com/project/Teaming/global/result/ResultCode.java
+++ b/src/main/java/com/project/Teaming/global/result/ResultCode.java
@@ -72,7 +72,8 @@ public enum ResultCode {
     REPORT_TEAM_USER(200, "M020", "멘토링 팀원 신고 완료"),
     REVIEW_TEAM_USER(200, "M021", "멘토링 팀원에게 리뷰작성 완료"),
     FIND_MENTORING_CATEGORY(200, "M022", "멘토링 모집 카테고리 조회완료"),
-    FIND_ALL_MENTORING_CATEGORY(200, "M023", "멘토링의 모든 모집 카테고리 조회완료");
+    FIND_ALL_MENTORING_CATEGORY(200, "M023", "멘토링의 모든 모집 카테고리 조회완료"),
+    GET_ALL_USER_MENTORING_TEAM(200,"M024","유저의 모든 멘토링팀 모두 조회완료");
 
     private int status;
     private final String code;


### PR DESCRIPTION
## 📌 연관된 이슈 
#125 
팀의 상태가 complete인 경우에만 isReviewed컬럼이반환되도록 구현
나의 모든 멘토링팀, 유저의 모든 멘토링팀 찾는 api user로 옮김
