### PR TITLE
refactor: 강퇴, 탈퇴시 알림가는 유저 수정 #198

### DIFF
--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/ParticipationRepositoryCustom.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/ParticipationRepositoryCustom.java
@@ -25,7 +25,7 @@ public interface ParticipationRepositoryCustom {
     );
 
     List<User> findMemberUser(
-            Long teamId);
+            Long teamId,MentoringAuthority mentoringAuthority);
 
     Optional<MentoringParticipation> findFirstUser(Long teamId, MentoringParticipationStatus participationStatus, MentoringAuthority authority);
     List<MentoringParticipation> findParticipationWithStatusAndUser(User user, MentoringParticipationStatus status);

--- a/src/main/java/com/project/Teaming/domain/mentoring/repository/ParticipationRepositoryCustomImpl.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/repository/ParticipationRepositoryCustomImpl.java
@@ -137,20 +137,24 @@ public class ParticipationRepositoryCustomImpl implements ParticipationRepositor
                 .fetch();
     }
     @Override
-    public List<User> findMemberUser(Long teamId) {
+    public List<User> findMemberUser(Long teamId, MentoringAuthority mentoringAuthority) {
 
         QMentoringParticipation mp = QMentoringParticipation.mentoringParticipation;
         QUser u = QUser.user;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(mp.mentoringTeam.id.eq(teamId));
+        builder.and(mp.participationStatus.eq(MentoringParticipationStatus.ACCEPTED));
+
+        if (mentoringAuthority != null) {
+            builder.and(mp.authority.eq(mentoringAuthority));
+        }
 
         return queryFactory
                 .select(u)
                 .from(mp)
                 .join(mp.user, u)
-                .where(
-                        mp.participationStatus.eq(MentoringParticipationStatus.ACCEPTED),
-                        mp.authority.eq(MentoringAuthority.CREW),
-                        mp.mentoringTeam.id.eq(teamId)
-                )
+                .where(builder)
                 .fetch();
     }
 

--- a/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringParticipationService.java
+++ b/src/main/java/com/project/Teaming/domain/mentoring/service/MentoringParticipationService.java
@@ -180,6 +180,7 @@ public class MentoringParticipationService {
         TeamUserResponse exportedParticipation = export.export();
         redisTeamUserManagementService.saveParticipation(mentoringTeam.getId(), exportUser.getId(), exportedParticipation);
         removeTeamUser(export,exportUser,mentoringTeam);
+        mentoringNotificationService.notifyExportedUser(userId,teamId);
         return mentoringNotificationService.export(userId,teamId);
     }
 

--- a/src/main/java/com/project/Teaming/global/sse/entity/NotificationType.java
+++ b/src/main/java/com/project/Teaming/global/sse/entity/NotificationType.java
@@ -8,12 +8,13 @@ import lombok.Getter;
 public enum NotificationType {
 
     TEAM_JOIN_REQUEST("프로젝트"),
-    MENTORING_TEAM_JOIN_REQUEST("멘토링"),
-    MENTORING_TEAM_ACCEPT("멘토링"),
-    MENTORING_TEAM_REJECT("멘토링"),
-    MENTORING_EXPORT("멘토링"),
-    MENTORING_DELETE("멘토링"),
-    WARNING_COUNT_INCREMENT("멘토링");
+    MENTORING_TEAM_JOIN_REQUEST("멘토링 팀 신청 알림"),
+    MENTORING_TEAM_ACCEPT("멘토링 수락 알림"),
+    MENTORING_TEAM_REJECT("멘토링 거절 알림"),
+    MENTORING_EXPORT("멘토링 강퇴 알림"),
+    MENTORING_EXPORT2("멘토링 강퇴된 유저에게 가는 알림"),
+    MENTORING_DELETE("멘토링 탈퇴 알림"),
+    WARNING_COUNT_INCREMENT("멘토링 경고횟수 증가 알림");
 
     private String title;
 }


### PR DESCRIPTION
## 📌 연관된 이슈 
#198 

- 강퇴시, 팀원과 강퇴된 유저에게 알림이 가도록,
- 탈퇴시, 리더와 팀원에게 알림이 가도록 수정
